### PR TITLE
Run Trello and Github interactive linters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'octokit', github: 'octokit/octokit.rb'
+
 group :test do
   gem 'codeclimate-test-reporter'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'octokit', github: 'octokit/octokit.rb'
-
 group :test do
   gem 'codeclimate-test-reporter'
 end

--- a/lib/scrum_lint.rb
+++ b/lib/scrum_lint.rb
@@ -26,6 +26,7 @@ require_relative 'scrum_lint/interactive_linters/card/missing_hash_tag'
 require_relative 'scrum_lint/interactive_linters/card/missing_label'
 long_name = 'scrum_lint/interactive_linters/pull_request/missing_milestone'
 require_relative long_name
+require_relative 'scrum_lint/interactive_linters/pull_request/missing_reviewer'
 
 require_relative 'scrum_lint/version'
 require_relative 'scrum_lint/configuration'

--- a/lib/scrum_lint.rb
+++ b/lib/scrum_lint.rb
@@ -24,6 +24,8 @@ require_relative 'scrum_lint/interactive_linters/card/missing_checklist_item'
 require_relative 'scrum_lint/interactive_linters/card/missing_context'
 require_relative 'scrum_lint/interactive_linters/card/missing_hash_tag'
 require_relative 'scrum_lint/interactive_linters/card/missing_label'
+long_name = 'scrum_lint/interactive_linters/pull_request/missing_milestone'
+require_relative long_name
 
 require_relative 'scrum_lint/version'
 require_relative 'scrum_lint/configuration'
@@ -37,6 +39,7 @@ require_relative 'scrum_lint/taggers/list_tagger'
 require_relative 'scrum_lint/mappers/octokit/source'
 require_relative 'scrum_lint/mappers/octokit/repo_mapper'
 require_relative 'scrum_lint/mappers/octokit/issue_mapper'
+require_relative 'scrum_lint/mappers/octokit/pull_request_mapper'
 require_relative 'scrum_lint/mappers/trello/source'
 require_relative 'scrum_lint/mappers/trello/board_mapper'
 require_relative 'scrum_lint/mappers/trello/list_mapper'
@@ -49,6 +52,7 @@ require_relative 'scrum_lint/models/list'
 require_relative 'scrum_lint/models/board'
 require_relative 'scrum_lint/models/repo'
 require_relative 'scrum_lint/models/issue'
+require_relative 'scrum_lint/models/pull_request'
 
 # Hack override to prevent Launchy from opening buttloads of tabs
 module Launchy

--- a/lib/scrum_lint/configuration.rb
+++ b/lib/scrum_lint/configuration.rb
@@ -17,6 +17,7 @@ module ScrumLint
       ignored_list_names: %w(Emergent),
       repo_source: 'Octokit',
       board_source: 'Trello',
+      github_reviewers: [],
     }.freeze
 
     REQUIRED_CONFIGURATION_KEYS = [

--- a/lib/scrum_lint/configuration.rb
+++ b/lib/scrum_lint/configuration.rb
@@ -18,6 +18,7 @@ module ScrumLint
       repo_source: 'Octokit',
       board_source: 'Trello',
       github_reviewers: [],
+      github_out_of_office: [],
     }.freeze
 
     REQUIRED_CONFIGURATION_KEYS = [

--- a/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
@@ -9,13 +9,16 @@ module ScrumLint
         /\AContext: (?<context_link>.*)\/.*$/i =~ card.desc
         return unless context_link
 
+        unless context_link =~ /trello.com/
+          raise "invalid context link for #{card.name.color(:green)}"
+        end
+
         project_card = project_cards.detect do |p_card|
           context_link.include?(p_card.short_url)
         end
 
         unless project_card
           project_card = lookup_project_card(context_link)
-
           unless project_card
             raise "no project found for context: #{card.name.color(:green)}"
           end

--- a/lib/scrum_lint/interactive_linters/card/missing_context.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_context.rb
@@ -9,14 +9,15 @@ module ScrumLint
 
         puts "#{card.name.color(:green)} is missing 'Context' link"
 
-        print_indexed(active_project_cards, :name)
+        sorted_active_project_cards = active_project_cards.sort_by(&:name)
+        print_indexed(sorted_active_project_cards, :name)
         print 'enter project number > '
         project_number = gets
         goodbye unless project_number
 
         return if project_number == "\n"
 
-        project_card = active_project_cards[Integer(project_number) - 1]
+        project_card = sorted_active_project_cards[Integer(project_number) - 1]
         card.desc = "Context: #{project_card.url}\n\n#{card.desc}".strip
         Thread.new { card.save }
       end

--- a/lib/scrum_lint/interactive_linters/card/missing_label.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_label.rb
@@ -6,12 +6,13 @@ module ScrumLint
       def call(card, available_labels:, **_)
         return if label?(card)
 
+        sorted_labels = available_labels.sort_by(&:name)
         puts "card missing label: #{card.name.color(:green)}"
-        print_indexed(available_labels, :name)
+        print_indexed(sorted_labels, :name)
         print 'enter label number > '
         label_number = gets
         goodbye unless label_number
-        label = available_labels[Integer(label_number) - 1]
+        label = sorted_labels[Integer(label_number) - 1]
         card.add_label(label)
       end
 

--- a/lib/scrum_lint/interactive_linters/pull_request/missing_milestone.rb
+++ b/lib/scrum_lint/interactive_linters/pull_request/missing_milestone.rb
@@ -1,0 +1,23 @@
+module ScrumLint
+  module InteractiveLinter
+    # checks for pull requests on Github that aren't associated with a milestone
+    class MissingMilestone < InteractiveLinter::Base
+
+      include Callable
+
+      def call(pull_request, milestones:, **)
+        return if pull_request.milestone
+        puts "Pull request #{pull_request.title.color(:red)}" \
+          " is missing a milestone."
+        print_indexed(milestones, :title)
+        print 'enter milestone number > '
+        milestone_number = gets
+        goodbye unless milestone_number
+        return if milestone_number.blank?
+        milestone = milestones[Integer(milestone_number) - 1]
+        pull_request.update(milestone: milestone.number)
+      end
+
+    end
+  end
+end

--- a/lib/scrum_lint/interactive_linters/pull_request/missing_milestone.rb
+++ b/lib/scrum_lint/interactive_linters/pull_request/missing_milestone.rb
@@ -7,14 +7,16 @@ module ScrumLint
 
       def call(pull_request, milestones:, **)
         return if pull_request.milestone
+
+        sorted_milestones = milestones.sort_by(&:title)
         puts "Pull request #{pull_request.title.color(:red)}" \
           " is missing a milestone."
-        print_indexed(milestones, :title)
+        print_indexed(sorted_milestones, :title)
         print 'enter milestone number > '
         milestone_number = gets
         goodbye unless milestone_number
         return if milestone_number.blank?
-        milestone = milestones[Integer(milestone_number) - 1]
+        milestone = sorted_milestones[Integer(milestone_number) - 1]
         pull_request.update(milestone: milestone.number)
       end
 

--- a/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
+++ b/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
@@ -1,0 +1,27 @@
+module ScrumLint
+  module InteractiveLinter
+    # checks for pull requests on Github that need a reviewer
+    class MissingReviewer < InteractiveLinter::Base
+
+      include Callable
+
+      def call(pull_request, reviewers:, **)
+        return if pull_request.reviewers.any? || pull_request.assignees.any?
+
+        shuffled_reviewers = (reviewers - [pull_request.author]).shuffle
+
+        puts "PR #{pull_request.name.color(:red)}, " \
+          "#{pull_request.author.color(:green)} needs reviewer"
+        print_indexed(shuffled_reviewers, :itself)
+        print 'Enter reviewer number > '
+
+        reviewer_number = gets
+        goodbye unless reviewer_number
+        return if reviewer_number.blank?
+        reviewer = shuffled_reviewers[Integer(reviewer_number) -1]
+        pull_request.update(assignee: reviewer, reviewers: [reviewer])
+      end
+
+    end
+  end
+end

--- a/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
+++ b/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
@@ -9,16 +9,25 @@ module ScrumLint
         return if pull_request.reviewers.any? || pull_request.assignees.any?
 
         shuffled_reviewers = (reviewers - [pull_request.author]).shuffle
+        reviewer = shuffled_reviewers.first
 
-        puts "PR #{pull_request.name.color(:red)}, " \
-          "#{pull_request.author.color(:green)} needs reviewer"
-        print_indexed(shuffled_reviewers, :itself)
-        print 'Enter reviewer number > '
+        puts "Assigning #{reviewer.color(:green)} to " \
+          "PR #{pull_request.name.color(:red)} " \
+          "(#{pull_request.author.color(:yellow)}). " \
+          "Type 's' to manually assign (ENTER/s)> "
 
-        reviewer_number = gets
-        goodbye unless reviewer_number
-        return if reviewer_number.blank?
-        reviewer = shuffled_reviewers[Integer(reviewer_number) -1]
+        choice = gets
+        goodbye unless choice.strip == 's' || choice.strip.empty?
+
+        if choice.strip == 's'
+          print_indexed(shuffled_reviewers, :itself)
+          print 'Enter reviewer number > '
+          reviewer_number = gets
+          goodbye unless reviewer_number
+          return if reviewer_number.blank?
+          reviewer = shuffled_reviewers[Integer(reviewer_number) -1]
+        end
+
         pull_request.update(assignee: reviewer, reviewers: [reviewer])
       end
 

--- a/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
+++ b/lib/scrum_lint/interactive_linters/pull_request/missing_reviewer.rb
@@ -8,7 +8,8 @@ module ScrumLint
       def call(pull_request, reviewers:, **)
         return if pull_request.reviewers.any? || pull_request.assignees.any?
 
-        shuffled_reviewers = (reviewers - [pull_request.author]).shuffle
+        exceptions = ScrumLint.config.github_out_of_office + [pull_request.author]
+        shuffled_reviewers = (reviewers - exceptions).shuffle
         reviewer = shuffled_reviewers.first
 
         puts "Assigning #{reviewer.color(:green)} to " \

--- a/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
+++ b/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
@@ -1,0 +1,27 @@
+module ScrumLint
+  module Octokit
+    # a mapper class to turn Octokit pull request into ScrumLint pull request
+    class PullRequestMapper
+
+      include Callable
+
+      def call(octokit_pull_request, client:)
+        ScrumLint::PullRequest.new(pull_request_params(octokit_pull_request, client))
+      end
+
+    private
+
+      def pull_request_params(octokit_pull_request, client)
+        {
+          client: client,
+          link: octokit_pull_request[:html_url],
+          milestone: octokit_pull_request[:milestone],
+          number: octokit_pull_request[:number],
+          repo_name: octokit_pull_request.head.repo.full_name,
+          title: octokit_pull_request[:title],
+        }
+      end
+
+    end
+  end
+end

--- a/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
+++ b/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
@@ -12,12 +12,18 @@ module ScrumLint
     private
 
       def pull_request_params(octokit_pull_request, client)
+        repo_name = octokit_pull_request.head.repo.full_name
+        number = octokit_pull_request[:number]
+
         {
+          assignees: octokit_pull_request[:assignees].map(&:login),
+          author: octokit_pull_request[:user].login,
           client: client,
           link: octokit_pull_request[:html_url],
           milestone: octokit_pull_request[:milestone],
-          number: octokit_pull_request[:number],
-          repo_name: octokit_pull_request.head.repo.full_name,
+          number: number,
+          repo_name: repo_name,
+          reviewers: client.pull_request_review_requests(repo_name, number).map(&:login),
           title: octokit_pull_request[:title],
         }
       end

--- a/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
+++ b/lib/scrum_lint/mappers/octokit/pull_request_mapper.rb
@@ -23,7 +23,11 @@ module ScrumLint
           milestone: octokit_pull_request[:milestone],
           number: number,
           repo_name: repo_name,
-          reviewers: client.pull_request_review_requests(repo_name, number).map(&:login),
+          reviewers: client.pull_request_review_requests(
+            repo_name,
+            number,
+            accept: 'application/vnd.github.black-cat-preview+json',
+          ).map(&:login),
           title: octokit_pull_request[:title],
         }
       end

--- a/lib/scrum_lint/mappers/octokit/repo_mapper.rb
+++ b/lib/scrum_lint/mappers/octokit/repo_mapper.rb
@@ -5,14 +5,18 @@ module ScrumLint
 
       include Callable
 
-      def call(octokit_repo)
-        ScrumLint::Repo.new(repo_params(octokit_repo))
+      def call(octokit_repo, client:)
+        ScrumLint::Repo.new(repo_params(octokit_repo, client))
       end
 
     private
 
-      def repo_params(octokit_repo)
-        { issues: mapped_issues(octokit_repo) }
+      def repo_params(octokit_repo, client)
+        {
+          issues: mapped_issues(octokit_repo),
+          pull_requests: mapped_pull_requests(octokit_repo, client),
+          context: { milestones: octokit_repo.rels[:milestones].get.data },
+        }
       end
 
       def mapped_issues(octokit_repo)
@@ -21,8 +25,18 @@ module ScrumLint
         end
       end
 
+      def mapped_pull_requests(octokit_repo, client)
+        octokit_repo.rels[:pulls].get.data.map do |octokit_pull_request|
+          pull_request_mapper.(octokit_pull_request, client: client)
+        end
+      end
+
       def issue_mapper
         @issue_mapper ||= ScrumLint::Octokit::IssueMapper.new
+      end
+
+      def pull_request_mapper
+        @pull_request_mapper ||= ScrumLint::Octokit::PullRequestMapper.new
       end
 
     end

--- a/lib/scrum_lint/mappers/octokit/repo_mapper.rb
+++ b/lib/scrum_lint/mappers/octokit/repo_mapper.rb
@@ -15,7 +15,10 @@ module ScrumLint
         {
           issues: mapped_issues(octokit_repo),
           pull_requests: mapped_pull_requests(octokit_repo, client),
-          context: { milestones: octokit_repo.rels[:milestones].get.data },
+          context: {
+            milestones: octokit_repo.rels[:milestones].get.data,
+            reviewers: ScrumLint.config.github_reviewers,
+          },
         }
       end
 

--- a/lib/scrum_lint/mappers/octokit/source.rb
+++ b/lib/scrum_lint/mappers/octokit/source.rb
@@ -10,7 +10,7 @@ module ScrumLint
 
       def call
         ScrumLint.config.github_repo_names.map do |repo_name|
-          repo_mapper.(client.repository(repo_name))
+          repo_mapper.(client.repository(repo_name), client: client)
         end
       end
 

--- a/lib/scrum_lint/models/pull_request.rb
+++ b/lib/scrum_lint/models/pull_request.rb
@@ -2,18 +2,22 @@ module ScrumLint
   # a wrapper class for Sawyer::Resource returned by Octokit
   class PullRequest
 
-    attr_reader :client, :link, :milestone, :number, :repo_name, :title
+    attr_reader :assignees, :author, :client, :link, :milestone, :number, :repo_name, :reviewers, :title
 
-    def initialize(client:, link:, milestone:, number:, repo_name:, title:)
+    def initialize(assignees:, author:, client:, link:, milestone:, number:, repo_name:, reviewers:, title:)
+      @assignees = assignees
+      @author = author
       @client = client
       @link = link
       @milestone = milestone
       @number = number
       @repo_name = repo_name
+      @reviewers = reviewers
       @title = title
     end
 
-    def update(**params)
+    def update(reviewers: nil, **params)
+      assign_reviewers(reviewers) if reviewers
       client.update_issue(repo_name, number, params)
     end
 
@@ -36,5 +40,13 @@ module ScrumLint
       :pull_request
     end
 
+  private
+    def assign_reviewers(reviewers)
+      client.request_pull_request_review(
+        repo_name,
+        number,
+        reviewers,
+      )
+    end
   end
 end

--- a/lib/scrum_lint/models/pull_request.rb
+++ b/lib/scrum_lint/models/pull_request.rb
@@ -1,0 +1,40 @@
+module ScrumLint
+  # a wrapper class for Sawyer::Resource returned by Octokit
+  class PullRequest
+
+    attr_reader :client, :link, :milestone, :number, :repo_name, :title
+
+    def initialize(client:, link:, milestone:, number:, repo_name:, title:)
+      @client = client
+      @link = link
+      @milestone = milestone
+      @number = number
+      @repo_name = repo_name
+      @title = title
+    end
+
+    def update(**params)
+      client.update_issue(repo_name, number, params)
+    end
+
+    def name
+      title
+    end
+
+    def tags
+      [:open]
+    end
+
+    def sub_entities
+      []
+    end
+
+    def each
+    end
+
+    def to_sym
+      :pull_request
+    end
+
+  end
+end

--- a/lib/scrum_lint/models/pull_request.rb
+++ b/lib/scrum_lint/models/pull_request.rb
@@ -46,6 +46,7 @@ module ScrumLint
         repo_name,
         number,
         reviewers,
+        accept: 'application/vnd.github.black-cat-preview+json',
       )
     end
   end

--- a/lib/scrum_lint/models/repo.rb
+++ b/lib/scrum_lint/models/repo.rb
@@ -2,18 +2,20 @@ module ScrumLint
   # a wrapper class for a Github repo from Octokit
   class Repo
 
-    attr_reader :issues
+    attr_reader :issues, :pull_requests, :context
 
-    def initialize(issues:)
+    def initialize(issues:, pull_requests:, context:)
+      @context = context
       @issues = issues
+      @pull_requests = pull_requests
     end
 
     def sub_entities
-      issues
+      pull_requests
     end
 
     def each
-      issues.each { |issue| yield(issue) }
+      pull_requests.each { |pull_request| yield(pull_request) }
     end
 
     def tags

--- a/lib/scrum_lint/runner.rb
+++ b/lib/scrum_lint/runner.rb
@@ -49,6 +49,7 @@ module ScrumLint
       issue: {},
       pull_request: {
         InteractiveLinter::MissingMilestone => [:open],
+        InteractiveLinter::MissingReviewer => [:open],
       },
     }.freeze
 

--- a/lib/scrum_lint/runner.rb
+++ b/lib/scrum_lint/runner.rb
@@ -47,17 +47,21 @@ module ScrumLint
       },
       repo: {},
       issue: {},
+      pull_request: {
+        InteractiveLinter::MissingMilestone => [:open],
+      },
     }.freeze
 
     def call(args = ARGV)
       options = ScrumLint::OptionParser.(args)
 
       ScrumLint::Configurator.()
-      boards
+      # boards
       puts
       if options[:interactive]
         reporter = ScrumLint::Reporters::InteractiveReporter.new
-        run_interactive_linters(boards, context: { reporter: reporter })
+        # run_interactive_linters(boards, context: { reporter: reporter })
+        run_interactive_linters(repos, context: { reporter: reporter })
       else
         boards.each { |entity| run_linters(entity) }
         repos.each { |repo| run_linters(repo) }
@@ -65,10 +69,6 @@ module ScrumLint
     end
 
   private
-
-    def repos
-      ScrumLint.config.repo_source_class.()
-    end
 
     def run_interactive_linters(entities, context:)
       return unless entities.any?
@@ -112,6 +112,10 @@ module ScrumLint
 
     def boards
       @boards ||= ScrumLint.config.board_source_class.()
+    end
+
+    def repos
+      @repos ||= ScrumLint.config.repo_source_class.()
     end
 
   end

--- a/lib/scrum_lint/runner.rb
+++ b/lib/scrum_lint/runner.rb
@@ -61,7 +61,7 @@ module ScrumLint
       puts
       if options[:interactive]
         reporter = ScrumLint::Reporters::InteractiveReporter.new
-        # run_interactive_linters(boards, context: { reporter: reporter })
+        run_interactive_linters(boards, context: { reporter: reporter })
         run_interactive_linters(repos, context: { reporter: reporter })
       else
         boards.each { |entity| run_linters(entity) }

--- a/scrum_lint.gemspec
+++ b/scrum_lint.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'launchy', '~> 2.4.3'
   spec.add_dependency 'rainbow', '~> 2.1.0'
   spec.add_dependency 'ruby-trello', '~> 1.4'
-  # spec.add_dependency 'octokit', '~> 4.3.0' # This version does not have review API
+  spec.add_dependency 'octokit', '~> 4.7.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'byebug', '~> 8.2'

--- a/scrum_lint.gemspec
+++ b/scrum_lint.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'launchy', '~> 2.4.3'
   spec.add_dependency 'rainbow', '~> 2.1.0'
   spec.add_dependency 'ruby-trello', '~> 1.4'
-  spec.add_dependency 'octokit', '~> 4.3.0'
+  # spec.add_dependency 'octokit', '~> 4.3.0' # This version does not have review API
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'byebug', '~> 8.2'


### PR DESCRIPTION
This PR is rebased off of a bunch of branches that add the following:
- This PR's commit: Un-comments the interactive linter for Trello so both
Trello and GitHub can run at the same time
- a8441e0, [better-handle-card-context](https://github.com/thread-pond/scrum-lint/tree/better-handle-card-context): Throws an error if someone uses
the word `context` on the card, and notifies you of which card it is.
- 34c9651, [alphabetize-all-the-things](https://github.com/thread-pond/scrum-lint/tree/alphabetize-all-the-things): Alphabetizes Trello card labels and
contexts in the interactive linter.
- 968b8a8, [missing-reviewer](https://github.com/thread-pond/scrum-lint/tree/missing-reviewer) (and before): Creates interactive linters for
Github pull request reviewers and milestones.