### PR TITLE
Fixes tests on master

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,9 @@ Metrics/CyclomaticComplexity:
 Metrics/ParameterLists:
   Max: 10
 
+Style/AccessorMethodName:
+  Enabled: false
+
 # default disabled rules
 Style/AutoResourceCleanup:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.3
 before_install: gem install bundler -v 1.11.2
 script:
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  gem 'codeclimate-test-reporter'
-end

--- a/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
@@ -63,7 +63,7 @@ module ScrumLint
         ScrumLint::Trello::CardMapper.(
           trello_card,
           list: trello_card.list,
-          board_name: trello_card.board.name,
+          board_name: trello_card.board.name
         )
       end
 

--- a/lib/scrum_lint/interactive_linters/card/missing_hash_tag.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_hash_tag.rb
@@ -3,7 +3,7 @@ module ScrumLint
     # checks that cards have #HashTag and interactively assigns
     class MissingHashTag < InteractiveLinter::Base
 
-      MESSAGE = 'missing hashtag'
+      MESSAGE = 'missing hashtag'.freeze
 
       def call(card, reporter:, **_)
         return if card.hashtags.any?

--- a/lib/scrum_lint/mappers/trello/list_mapper.rb
+++ b/lib/scrum_lint/mappers/trello/list_mapper.rb
@@ -10,7 +10,7 @@ module ScrumLint
           list.cards = mapped_cards(
             list: list,
             trello_list: trello_list,
-            board_name: board_name,
+            board_name: board_name
           )
         end
       end

--- a/spec/fixtures/scrum-lint.yml
+++ b/spec/fixtures/scrum-lint.yml
@@ -1,3 +1,4 @@
 trello_developer_public_key: nope
 trello_member_token: nada
 github_access_token: foo
+github_repo_names: ['foo/bar']

--- a/spec/scrum_lint/models/card_spec.rb
+++ b/spec/scrum_lint/models/card_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe ScrumLint::Card do
   let(:card_params) do
     {
+      board_name: nil,
       checklists: nil,
       desc: nil,
       labels: nil,

--- a/spec/scrum_lint/runner_spec.rb
+++ b/spec/scrum_lint/runner_spec.rb
@@ -3,7 +3,12 @@ module ScrumLint
     let(:runner) { described_class.new }
 
     before(:each) do
+      allow(Launchy).to receive(:open)
+
       allow(::Trello::Board).to receive(:all).and_return([fake_trello_board])
+      allow(::Trello::Card).to receive(:find).and_return(fake_trello_card)
+
+      allow(Octokit::Source).to receive(:call).and_return([])
     end
 
     it 'configures trello settings' do
@@ -13,19 +18,68 @@ module ScrumLint
     end
 
     it 'validates the selected board' do
-      allow(Linter::MissingTaskList).to receive(:call).and_call_original
       allow(Linter::ExtraList).to receive(:call).and_call_original
+      allow(Linter::ExtraDoneList).to receive(:call).and_call_original
+      allow(Linter::MissingTaskList).to receive(:call).and_call_original
       runner.([])
+      expect(Linter::ExtraList).to have_received(:call)
+        .with(instance_of(Board))
+      expect(Linter::ExtraDoneList).to have_received(:call)
+        .with(instance_of(Board))
       expect(Linter::MissingTaskList).to have_received(:call)
         .with(instance_of(Board))
-      expect(Linter::ExtraList).to have_received(:call).with(instance_of(Board))
     end
 
-    it 'checks contexts' do
-      allow(Linter::MissingContext).to receive(:call).and_call_original
-      runner.([])
-      expect(Linter::MissingContext).to have_received(:call)
-        .with(instance_of(Board))
+    describe 'card linters' do
+      it 'runs for cards with "task" and "active" tags' do
+        allow(Linter::MissingHashTag).to receive(:call).and_call_original
+        allow(Linter::MissingContext).to receive(:call).and_call_original
+        allow(Linter::MissingExpendedPoints).to receive(:call)
+        runner.([])
+        expect(Linter::MissingHashTag).to have_received(:call)
+          .with(instance_of(Card))
+        expect(Linter::MissingContext).to have_received(:call)
+          .with(instance_of(Card))
+        expect(Linter::MissingExpendedPoints).not_to have_received(:call)
+      end
+
+      it 'runs for cards with "task" and "done" tags' do
+        allow(ScrumLint::CardTagger).to receive(:call)
+          .and_return([:task, :done])
+        allow(Linter::MissingHashTag).to receive(:call).and_call_original
+        allow(Linter::MissingContext).to receive(:call)
+        allow(Linter::MissingExpendedPoints).to receive(:call).and_call_original
+        runner.([])
+        expect(Linter::MissingHashTag).to have_received(:call)
+          .with(instance_of(Card))
+        expect(Linter::MissingContext).not_to have_received(:call)
+        expect(Linter::MissingExpendedPoints).to have_received(:call)
+          .with(instance_of(Card))
+      end
+
+      it 'runs for cards with "task" tags' do
+        allow(ScrumLint::CardTagger).to receive(:call).and_return([:task])
+        allow(Linter::MissingHashTag).to receive(:call).and_call_original
+        allow(Linter::MissingContext).to receive(:call)
+        allow(Linter::MissingExpendedPoints).to receive(:call)
+        runner.([])
+        expect(Linter::MissingHashTag).to have_received(:call)
+          .with(instance_of(Card))
+        expect(Linter::MissingContext).not_to have_received(:call)
+        expect(Linter::MissingExpendedPoints).not_to have_received(:call)
+      end
+
+      it 'runs no linters for cards with "project" tags' do
+        allow(ScrumLint::CardTagger).to receive(:call).and_return([:project])
+        allow(Linter::MissingHashTag).to receive(:call)
+        allow(Linter::MissingContext).to receive(:call)
+        allow(Linter::MissingExpendedPoints).to receive(:call)
+        runner.([])
+        expect(Linter::MissingHashTag).not_to have_received(:call)
+          .with(instance_of(Card))
+        expect(Linter::MissingContext).not_to have_received(:call)
+        expect(Linter::MissingExpendedPoints).not_to have_received(:call)
+      end
     end
   end
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -3,12 +3,7 @@ if ENV['TRAVIS'] || ENV['COVERAGE']
   SimpleCov.add_filter '/spec/'
   SimpleCov.add_filter '/vendor/bundle/'
 
-  if ENV['TRAVIS']
-    require 'codeclimate-test-reporter'
-    CodeClimate::TestReporter.start
-  else
-    SimpleCov.start
-  end
+  SimpleCov.start
 
   SimpleCov.command_name "rspec_#{Process.pid}"
 end

--- a/spec/support/fake_builders.rb
+++ b/spec/support/fake_builders.rb
@@ -1,8 +1,16 @@
 def fake_trello_card(name: 'What card', desc: 'some desc', **options)
-  instance_double(Trello::Card, name: name, desc: desc, **options)
+  instance_double(
+    Trello::Card,
+    name: name,
+    desc: desc,
+    card_labels: 'abc123',
+    short_url: 'https://foo.bar.baz.biz',
+    url: 'https://something.much.longer',
+    **options
+  )
 end
 
-def fake_trello_list(name: 'Planned', cards: [])
+def fake_trello_list(name: 'Planned', cards: [fake_trello_card])
   instance_double(Trello::List, name: name, cards: cards)
 end
 


### PR DESCRIPTION
**What**

- Fixes rubocop failures using default rules with the exception of one
case
- Removes CodeClimate from the code because its implementation was
deprecated on TravisCI. I opened an issue to look into this: https://github.com/thread-pond/scrum-lint/issues/7
- Added the latest stable ruby version (that RVM has to offer) to run on
TravisCI
- Did the minimum necessary to mock out the repo linter functionality so
that the existing tests will pass. I will make a follow-up eventually
to write tests for the repo linter.
- Fixed some small things in the existing tests to get them to pass
- Added test coverage to the `Runner` spec.