### PR TITLE
Upgrades: update dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Metrics/CyclomaticComplexity:
 Metrics/ParameterLists:
   Max: 10
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 # default disabled rules
@@ -42,35 +42,46 @@ Style/CollectionMethods:
     find: 'detect'
     find_all: 'select'
 
-Style/FirstArrayElementLineBreak:
+Layout/FirstArrayElementLineBreak:
   Enabled: true
 
-Style/FirstHashElementLineBreak:
+Layout/FirstHashElementLineBreak:
   Enabled: true
 
-Style/FirstMethodArgumentLineBreak:
+Layout/FirstMethodArgumentLineBreak:
   Enabled: true
 
-Style/FirstMethodParameterLineBreak:
+Layout/FirstMethodParameterLineBreak:
   Enabled: true
 
-Style/MultilineArrayBraceLayout:
+Layout/MultilineArrayBraceLayout:
   Enabled: true
 
-Style/MultilineHashBraceLayout:
+Layout/MultilineHashBraceLayout:
   Enabled: true
 
-Style/MultilineMethodCallBraceLayout:
+Layout/MultilineMethodCallBraceLayout:
   Enabled: true
 
-Style/MultilineMethodDefinitionBraceLayout:
+Layout/MultilineMethodDefinitionBraceLayout:
   Enabled: true
+
+Metrics/BlockLength:
+  Exclude:
+    - scrum_lint.gemspec
+    - spec/**/*_spec.rb
 
 Style/OptionHash:
   Enabled: true
 
 Style/Send:
   Enabled: true
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
 
 RSpec/VerifiedDoubles:
   Enabled: true
@@ -79,13 +90,16 @@ RSpec/VerifiedDoubles:
 Style/LambdaCall:
   EnforcedStyle: braces
 
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   EnforcedStyle: empty_lines
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 RSpec/DescribeMethod:

--- a/lib/scrum_lint/configuration.rb
+++ b/lib/scrum_lint/configuration.rb
@@ -14,16 +14,16 @@ module ScrumLint
       task_list_names: ['Planned', 'This Sprint', 'Doing', 'In Review'],
       done_list_matcher: /^Done.*$/,
       project_list_names: ['Active Projects'],
-      ignored_list_names: %w(Emergent),
+      ignored_list_names: %w[Emergent],
       repo_source: 'Octokit',
       board_source: 'Trello',
     }.freeze
 
-    REQUIRED_CONFIGURATION_KEYS = [
-      :trello_developer_public_key,
-      :trello_member_token,
-      :github_access_token,
-      :github_repo_names,
+    REQUIRED_CONFIGURATION_KEYS = %i[
+      trello_developer_public_key
+      trello_member_token
+      github_access_token
+      github_repo_names
     ].freeze
 
     CONFIGURATION_KEYS =

--- a/lib/scrum_lint/ext/trello/card.rb
+++ b/lib/scrum_lint/ext/trello/card.rb
@@ -5,7 +5,7 @@ module Trello
   class Card < BasicData
 
     def update_check_item_state(check_item, checklist:, state:)
-      unless %w(complete incomplete).include?(state)
+      unless %w[complete incomplete].include?(state)
         raise "invalid state #{state}"
       end
 

--- a/lib/scrum_lint/interactive_linters/card/checklist_item_not_completed.rb
+++ b/lib/scrum_lint/interactive_linters/card/checklist_item_not_completed.rb
@@ -5,7 +5,7 @@ module ScrumLint
 
       include Callable
 
-      def call(card, project_cards:, **_)
+      def call(card, project_cards:, **_context)
         /\AContext: (?<context_link>.*)\/.*$/i =~ card.desc
         return unless context_link
 
@@ -49,21 +49,21 @@ module ScrumLint
 
         check_item = check_items.first
 
-        if check_item.state == 'incomplete'
-          puts "task #{card.name.color(:green)} should be marked complete " \
-            "on project #{project_card.name.color(:blue)}"
-          print 'mark check item completed? (y/n) > '
-          confirmation = gets
-          goodbye unless confirmation
-          case confirmation.chomp.downcase
-          when '', 'y'
-            Thread.new do
-              options = { checklist: checklist, state: 'complete' }
-              project_card.update_check_item_state(check_item, options)
-            end
-          else
-            puts 'skipping card'
+        return unless check_item.state == 'incomplete'
+
+        puts "task #{card.name.color(:green)} should be marked complete " \
+          "on project #{project_card.name.color(:blue)}"
+        print 'mark check item completed? (y/n) > '
+        confirmation = gets
+        goodbye unless confirmation
+        case confirmation.chomp.downcase
+        when '', 'y'
+          Thread.new do
+            options = { checklist: checklist, state: 'complete' }
+            project_card.update_check_item_state(check_item, options)
           end
+        else
+          puts 'skipping card'
         end
       end
 

--- a/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_checklist_item.rb
@@ -5,7 +5,7 @@ module ScrumLint
     # checks that cards have a checklist item on associated Context card
     class MissingChecklistItem < InteractiveLinter::Base
 
-      def call(card, project_cards:, **_)
+      def call(card, project_cards:, **_context)
         /\AContext: (?<context_link>.*)\/.*$/i =~ card.desc
         return unless context_link
 

--- a/lib/scrum_lint/interactive_linters/card/missing_context.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_context.rb
@@ -4,7 +4,7 @@ module ScrumLint
     #   Context: <link to a trello card>
     class MissingContext < InteractiveLinter::Base
 
-      def call(card, active_project_cards:, **_)
+      def call(card, active_project_cards:, **_context)
         return if context?(card) || active_project_cards.empty?
 
         puts "#{card.name.color(:green)} is missing 'Context' link"

--- a/lib/scrum_lint/interactive_linters/card/missing_hash_tag.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_hash_tag.rb
@@ -5,7 +5,7 @@ module ScrumLint
 
       MESSAGE = 'missing hashtag'.freeze
 
-      def call(card, reporter:, **_)
+      def call(card, reporter:, **_context)
         return if card.hashtags.any?
 
         reporter.fail(card, MESSAGE)

--- a/lib/scrum_lint/interactive_linters/card/missing_label.rb
+++ b/lib/scrum_lint/interactive_linters/card/missing_label.rb
@@ -3,7 +3,7 @@ module ScrumLint
     # checks that cards have Trello labels and interactively assigns
     class MissingLabel < InteractiveLinter::Base
 
-      def call(card, available_labels:, **_)
+      def call(card, available_labels:, **_context)
         return if label?(card)
 
         puts "card missing label: #{card.name.color(:green)}"

--- a/lib/scrum_lint/models/card.rb
+++ b/lib/scrum_lint/models/card.rb
@@ -35,8 +35,7 @@ module ScrumLint
       []
     end
 
-    def each
-    end
+    def each; end
 
     def desc=(desc)
       @source.desc = desc

--- a/lib/scrum_lint/models/issue.rb
+++ b/lib/scrum_lint/models/issue.rb
@@ -18,8 +18,7 @@ module ScrumLint
       []
     end
 
-    def each
-    end
+    def each; end
 
     def to_sym
       :issue

--- a/lib/scrum_lint/runner.rb
+++ b/lib/scrum_lint/runner.rb
@@ -23,8 +23,8 @@ module ScrumLint
       },
       card: {
         [:task] => [Linter::MissingHashTag],
-        [:task, :active] => [Linter::MissingContext],
-        [:task, :done] => [Linter::MissingExpendedPoints],
+        %i[task active] => [Linter::MissingContext],
+        %i[task done] => [Linter::MissingExpendedPoints],
         [:project] => [],
       },
       repo: {
@@ -41,9 +41,9 @@ module ScrumLint
       card: {
         InteractiveLinter::MissingHashTag => [:task],
         InteractiveLinter::MissingLabel => [:task],
-        InteractiveLinter::MissingContext => [:task, :active],
-        InteractiveLinter::MissingChecklistItem => [:task, :active],
-        InteractiveLinter::ChecklistItemNotCompleted => [:task, :done],
+        InteractiveLinter::MissingContext => %i[task active],
+        InteractiveLinter::MissingChecklistItem => %i[task active],
+        InteractiveLinter::ChecklistItemNotCompleted => %i[task done],
       },
       repo: {},
       issue: {},

--- a/scrum_lint.gemspec
+++ b/scrum_lint.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+
 require_relative 'lib/scrum_lint/version'
 
 Gem::Specification.new do |spec|
@@ -12,25 +12,25 @@ Gem::Specification.new do |spec|
   spec.license  = 'MIT'
 
   spec.files         = `git ls-files lib util`.split($RS)
-  spec.files        += %w(README.md LICENSE.txt CODE_OF_CONDUCT.md)
+  spec.files        += %w[README.md LICENSE.txt CODE_OF_CONDUCT.md]
   spec.bindir        = 'exe'
   exe_files = `git ls-files exe`.split($RS).map { |f| File.basename(f) }
   spec.executables   = exe_files
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
 
   spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency 'launchy', '~> 2.4.3'
-  spec.add_dependency 'rainbow', '~> 2.1.0'
-  spec.add_dependency 'ruby-trello', '~> 1.4'
   spec.add_dependency 'octokit', '~> 4.3.0'
+  spec.add_dependency 'rainbow', '~> 3.0'
+  spec.add_dependency 'ruby-trello', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'byebug', '~> 8.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.37.1'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.3.1'
+  spec.add_development_dependency 'rubocop', '~> 0.55.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.25.1'
   spec.add_development_dependency 'simplecov', '~> 0.11.2'
   spec.add_development_dependency 'webmock', '~> 1.24.0'
 end

--- a/spec/scrum_lint/interactive_linters/card/missing_context_spec.rb
+++ b/spec/scrum_lint/interactive_linters/card/missing_context_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe ScrumLint::InteractiveLinter::MissingContext, '#call' do
       card = fake_trello_card(name: 'poop doop', desc: 'Context: fart/less')
       checker.(card, active_project_cards: [project_card, project_card_2])
 
-      expect(checker).to_not have_received(:desc=)
-      expect(checker).to_not have_received(:gets)
+      expect(checker).not_to have_received(:desc=)
+      expect(checker).not_to have_received(:gets)
     end
   end
 
@@ -118,8 +118,8 @@ RSpec.describe ScrumLint::InteractiveLinter::MissingContext, '#call' do
       card = fake_trello_card(name: 'poop doop', desc: 'talk less, fart more')
       checker.(card, active_project_cards: [])
 
-      expect(checker).to_not have_received(:desc=)
-      expect(checker).to_not have_received(:gets)
+      expect(checker).not_to have_received(:desc=)
+      expect(checker).not_to have_received(:gets)
     end
   end
 end

--- a/spec/scrum_lint/runner_spec.rb
+++ b/spec/scrum_lint/runner_spec.rb
@@ -2,7 +2,7 @@ module ScrumLint
   RSpec.describe Runner, '#call' do
     let(:runner) { described_class.new }
 
-    before(:each) do
+    before do
       allow(Launchy).to receive(:open)
 
       allow(::Trello::Board).to receive(:all).and_return([fake_trello_board])
@@ -45,7 +45,7 @@ module ScrumLint
 
       it 'runs for cards with "task" and "done" tags' do
         allow(ScrumLint::CardTagger).to receive(:call)
-          .and_return([:task, :done])
+          .and_return(%i[task done])
         allow(Linter::MissingHashTag).to receive(:call).and_call_original
         allow(Linter::MissingContext).to receive(:call)
         allow(Linter::MissingExpendedPoints).to receive(:call).and_call_original

--- a/spec/util/callable_spec.rb
+++ b/spec/util/callable_spec.rb
@@ -1,6 +1,6 @@
-# rubocop:disable Style/EmptyLinesAroundClassBody
+# rubocop:disable Layout/EmptyLinesAroundClassBody
 RSpec.describe Callable do
-  after(:each) do
+  after do
     if Object.const_defined?(:MyCallableClass)
       Object.__send__(:remove_const, :MyCallableClass)
     end
@@ -32,8 +32,7 @@ RSpec.describe Callable do
       class MyCallableClass
         include Callable
 
-        def bad_meth
-        end
+        def bad_meth; end
       end
     end.to raise_error(Callable::CallableError, /invalid method name bad_meth/)
   end
@@ -45,10 +44,9 @@ RSpec.describe Callable do
 
       private
 
-        def good_meth
-        end
+        def good_meth; end
       end
     end.not_to raise_error
   end
 end
-# rubocop:enable Style/EmptyLinesAroundClassBody
+# rubocop:enable Layout/EmptyLinesAroundClassBody


### PR DESCRIPTION
I set out to upgrade just Rubocop and RubocopRSpec, but they had a
shared dependency on Rainbows, so that had to go up, and Trello Ruby got
pulled in, too. So there you go.