### PR TITLE
Change `raise` to `warn` on invalid configuration

### DIFF
--- a/lib/scrum_lint/configuration.rb
+++ b/lib/scrum_lint/configuration.rb
@@ -38,7 +38,7 @@ module ScrumLint
         public_send("#{key}=", options.fetch(key))
         options.delete(key)
       end
-      raise "invalid options: #{options.keys}" if options.any?
+      warn "invalid options: #{options.keys}" if options.any?
     end
 
     def repo_source_class


### PR DESCRIPTION
This becomes a problem when you add keys to the config file for new
features that are not yet merged into master. Right now we have a branch
that makes use of `github_reviewers` inside of `.scrum-lint.yml`, but
then the build fails on master because it doesn't support that
configuration. A warning seems more appropriate for this case.